### PR TITLE
docs: fix outdated Chrome Web Store and Microsoft support URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Please note that NAS Download Manager is not an official Synology offering.
 
 The following browsers were supported in earlier versions, but made breaking changes since the extension was released.
 
-- Chrome ([view listing](https://chrome.google.com/webstore/detail/nas-download-manager/iaijiochiiocodhamehbpmdlobhgghgi))
-- Edge (see [how to install from Chrome Web Store](https://support.microsoft.com/en-us/help/4538971/microsoft-edge-add-or-remove-extensions) and use the Chrome link above)
+- Chrome ([view listing](https://chromewebstore.google.com/detail/nas-download-manager/iaijiochiiocodhamehbpmdlobhgghgi))
+- Edge (see [how to install from Chrome Web Store](https://support.microsoft.com/en-US/microsoft-edge/9c0ec68c-2fbc-2f2c-9ff0-bdc76f46b026) and use the Chrome link above)
 - Opera (using the [Install Chrome Extensions](https://addons.opera.com/en/extensions/details/install-chrome-extensions/) extension to install from the Chrome link above)
 
 There are currently no plans to support the following browsers.


### PR DESCRIPTION
## What
Fixed outdated URLs:
- Chrome Web Store: `chrome.google.com/webstore` → `chromewebstore.google.com`
- Microsoft Support: `support.microsoft.com/en-us/help/4538971/...` → `support.microsoft.com/en-US/microsoft-edge/...`

## Why
The old URLs redirect to the new format. Updating directly improves user experience.

## Links fixed
- `https://chrome.google.com/webstore/detail/nas-download-manager/iaijiochiiocodhamehbpmdlobhgghgi`
- `https://support.microsoft.com/en-us/help/4538971/microsoft-edge-add-or-remove-extensions`
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*